### PR TITLE
fix: use create-pull-request for scorecard updates

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   scorecard:
@@ -16,10 +17,11 @@ jobs:
       - uses: actions/checkout@v6
       - uses: markmishaev76/ai-harness-scorecard@v1
         id: scorecard
-      - name: Commit badge and report
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add scorecard-badge.json scorecard-report.md
-          git diff --cached --quiet || git commit -m "chore: update scorecard badge and report"
-          git push
+      - name: Create PR with badge and report
+        uses: peter-evans/create-pull-request@v7
+        with:
+          commit-message: "chore: update scorecard badge and report"
+          branch: chore/scorecard-update
+          title: "chore: update scorecard badge and report"
+          body: "Automated scorecard badge and report update."
+          delete-branch: true


### PR DESCRIPTION
## Summary

- The scorecard workflow was failing because `git push` to `main` is blocked by branch protection rules (required status checks + required reviews)
- The default `GITHUB_TOKEN` can't bypass rulesets on personal repos
- Replaced the direct `git push` with `peter-evans/create-pull-request@v7` so scorecard badge/report updates come in as PRs instead
- Added `pull-requests: write` permission to support PR creation

## Test plan

- [ ] Trigger the scorecard workflow via `workflow_dispatch` and confirm it creates a PR instead of failing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved security scorecard workflow: Automated pull request creation for scorecard badge and report updates, replacing manual commit and push operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->