### PR TITLE
Feat/resolve npm scripts

### DIFF
--- a/src/ai_harness_scorecard/ci_parser.py
+++ b/src/ai_harness_scorecard/ci_parser.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, cast
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -96,7 +96,7 @@ def _parse_gitlab_ci(path: Path) -> CIConfig | None:
     return config
 
 
-def _detect_gitlab_schedule(data: dict, config: CIConfig) -> None:
+def _detect_gitlab_schedule(data: dict[str, Any], config: CIConfig) -> None:
     for value in data.values():
         if not isinstance(value, dict):
             continue
@@ -111,7 +111,7 @@ def _detect_gitlab_schedule(data: dict, config: CIConfig) -> None:
                     return
 
 
-def _extract_gitlab_commands(job_data: dict) -> list[str]:
+def _extract_gitlab_commands(job_data: dict[str, Any]) -> list[str]:
     commands: list[str] = []
     for key in ("before_script", "script", "after_script"):
         scripts = job_data.get(key, [])
@@ -141,12 +141,16 @@ def _parse_github_actions(path: Path) -> CIConfig | None:
     return config
 
 
-def _is_github_scheduled(data: dict) -> bool:
-    on_triggers = data.get("on") or data.get(True, {})
+def _is_github_scheduled(data: dict[str, Any]) -> bool:
+    # In some YAML parsers, 'on' is interpreted as True (boolean)
+    on_triggers = data.get("on")
+    if on_triggers is None:
+        on_triggers = data.get(cast("str", True))
+
     return isinstance(on_triggers, dict) and "schedule" in on_triggers
 
 
-def _create_github_job(name: str, data: dict) -> CIJob:
+def _create_github_job(name: str, data: dict[str, Any]) -> CIJob:
     commands: list[str] = []
 
     job_uses = data.get("uses")
@@ -168,7 +172,7 @@ def _create_github_job(name: str, data: dict) -> CIJob:
     )
 
 
-def _load_yaml(path: Path) -> tuple[str, dict | None]:
+def _load_yaml(path: Path) -> tuple[str, dict[str, Any] | None]:
     try:
         raw = path.read_text(encoding="utf-8")
         data = yaml.safe_load(raw)

--- a/src/ai_harness_scorecard/repo_context.py
+++ b/src/ai_harness_scorecard/repo_context.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import re
 from dataclasses import dataclass, field
@@ -51,6 +52,7 @@ class RepoContext:
     file_tree: list[str] = field(default_factory=list)
     languages: list[str] = field(default_factory=list)
     ci_configs: list[CIConfig] = field(default_factory=list)
+    scripts: dict[str, str] = field(default_factory=dict)
 
     @classmethod
     def build(cls, repo_path: str | Path) -> RepoContext:
@@ -59,6 +61,7 @@ class RepoContext:
         ctx.file_tree = ctx._scan_file_tree()
         ctx.languages = ctx._detect_languages()
         ctx.ci_configs = parse_ci_configs(path)
+        ctx.scripts = ctx._load_scripts()
         return ctx
 
     def has_file(self, *patterns: str) -> str | None:
@@ -116,20 +119,30 @@ class RepoContext:
     def ci_has_command(self, pattern: str) -> bool:
         """Return True if any CI job contains a command matching the pattern."""
         regex = re.compile(pattern, re.IGNORECASE)
-        return any(
-            regex.search(cmd) for ci in self.ci_configs for job in ci.jobs for cmd in job.commands
-        )
+        for ci in self.ci_configs:
+            for job in ci.jobs:
+                if self._matches_command(job.commands, regex):
+                    return True
+        return False
 
     def ci_has_blocking_command(self, pattern: str) -> bool:
         """Return True if a non-allow_failure CI job contains a matching command."""
         regex = re.compile(pattern, re.IGNORECASE)
-        return any(
-            regex.search(cmd)
-            for ci in self.ci_configs
-            for job in ci.jobs
-            if not job.allow_failure
-            for cmd in job.commands
-        )
+        for ci in self.ci_configs:
+            for job in ci.jobs:
+                if not job.allow_failure and self._matches_command(job.commands, regex):
+                    return True
+        return False
+
+    def _matches_command(self, commands: list[str], regex: re.Pattern[str]) -> bool:
+        """Helper to match a regex against a list of commands, including script resolution."""
+        for cmd in commands:
+            if regex.search(cmd):
+                return True
+            resolved = self._resolve_script(cmd)
+            if resolved and regex.search(resolved):
+                return True
+        return False
 
     def ci_has_scheduled_job(self) -> bool:
         return any(ci.has_schedule for ci in self.ci_configs)
@@ -137,6 +150,46 @@ class RepoContext:
     def ci_raw_content(self) -> str:
         """Concatenated raw CI config content for text-level searches."""
         return "\n".join(ci.raw_content for ci in self.ci_configs)
+
+    def _load_scripts(self) -> dict[str, str]:
+        """Load scripts from package.json if it exists."""
+        content = self.read_file("package.json")
+        if not content:
+            return {}
+        try:
+            data = json.loads(content)
+            scripts = data.get("scripts", {})
+            if isinstance(scripts, dict):
+                return {k: str(v) for k, v in scripts.items()}
+        except (json.JSONDecodeError, TypeError):
+            pass
+        return {}
+
+    def _resolve_script(self, command: str) -> str | None:
+        """
+        Attempt to resolve a script name from an npm/yarn/pnpm/bun invocation.
+        Example: 'npm run lint' -> returns the content of 'lint' script.
+        """
+        parts = command.split()
+        if len(parts) < 2:
+            return None
+
+        pkg_manager = parts[0].lower()
+        if pkg_manager not in ("npm", "yarn", "pnpm", "bun"):
+            return None
+
+        script_name = None
+        if parts[1].lower() == "run":
+            if len(parts) >= 3:
+                script_name = parts[2]
+        elif pkg_manager in ("yarn", "pnpm", "bun"):
+            # yarn, pnpm, and bun allow omitting 'run' for custom scripts
+            script_name = parts[1]
+
+        if script_name and script_name in self.scripts:
+            return self.scripts[script_name]
+
+        return None
 
     def _scan_file_tree(self) -> list[str]:
         files: list[str] = []

--- a/src/ai_harness_scorecard/repo_context.py
+++ b/src/ai_harness_scorecard/repo_context.py
@@ -158,9 +158,10 @@ class RepoContext:
             return {}
         try:
             data = json.loads(content)
-            scripts = data.get("scripts", {})
-            if isinstance(scripts, dict):
-                return {k: str(v) for k, v in scripts.items()}
+            if isinstance(data, dict):
+                scripts = data.get("scripts", {})
+                if isinstance(scripts, dict):
+                    return {k: str(v) for k, v in scripts.items()}
         except (json.JSONDecodeError, TypeError):
             pass
         return {}

--- a/src/ai_harness_scorecard/reporters/json_reporter.py
+++ b/src/ai_harness_scorecard/reporters/json_reporter.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from ..models import Assessment, CategoryResult, CheckResult
@@ -14,7 +14,7 @@ def render_json(assessment: Assessment) -> str:
     return json.dumps(_serialize(assessment), indent=2)
 
 
-def _serialize(assessment: Assessment) -> dict:
+def _serialize(assessment: Assessment) -> dict[str, Any]:
     return {
         "repo_path": assessment.repo_path,
         "repo_name": assessment.repo_name,

--- a/src/ai_harness_scorecard/reporters/json_reporter.py
+++ b/src/ai_harness_scorecard/reporters/json_reporter.py
@@ -29,7 +29,7 @@ def _serialize(assessment: Assessment) -> dict[str, Any]:
     }
 
 
-def _serialize_category(category: CategoryResult) -> dict[str, object]:
+def _serialize_category(category: CategoryResult) -> dict[str, Any]:
     return {
         "category_id": category.category_id,
         "name": category.name,
@@ -41,7 +41,7 @@ def _serialize_category(category: CategoryResult) -> dict[str, object]:
     }
 
 
-def _serialize_check(check: CheckResult) -> dict[str, object]:
+def _serialize_check(check: CheckResult) -> dict[str, Any]:
     return {
         "check_id": check.check_id,
         "name": check.name,

--- a/tests/test_script_resolution.py
+++ b/tests/test_script_resolution.py
@@ -17,25 +17,24 @@ def repo_with_scripts(tmp_path: Path):
     """Create a temporary repo with a package.json containing scripts."""
     package_json = {
         "name": "test-repo",
-        "scripts": {
-            "lint": "eslint .",
-            "test": "jest",
-            "check": "ruff check ."
-        }
+        "scripts": {"lint": "eslint .", "test": "jest", "check": "ruff check ."},
     }
     (tmp_path / "package.json").write_text(json.dumps(package_json))
     return tmp_path
 
 
-@pytest.mark.parametrize("pkg_manager_cmd", [
-    "npm run lint",
-    "yarn lint",
-    "yarn run lint",
-    "pnpm lint",
-    "pnpm run lint",
-    "bun lint",
-    "bun run lint",
-])
+@pytest.mark.parametrize(
+    "pkg_manager_cmd",
+    [
+        "npm run lint",
+        "yarn lint",
+        "yarn run lint",
+        "pnpm lint",
+        "pnpm run lint",
+        "bun lint",
+        "bun run lint",
+    ],
+)
 def test_script_resolution_pass(repo_with_scripts: Path, pkg_manager_cmd: str):
     """Test that various package manager invocations resolve correctly."""
     # Create CI config using the linter script
@@ -44,14 +43,7 @@ def test_script_resolution_pass(repo_with_scripts: Path, pkg_manager_cmd: str):
     ci_config = {
         "name": "CI",
         "on": ["push"],
-        "jobs": {
-            "lint": {
-                "runs-on": "ubuntu-latest",
-                "steps": [
-                    {"run": pkg_manager_cmd}
-                ]
-            }
-        }
+        "jobs": {"lint": {"runs-on": "ubuntu-latest", "steps": [{"run": pkg_manager_cmd}]}},
     }
     (ci_dir / "ci.yml").write_text(yaml.dump(ci_config))
 
@@ -62,19 +54,20 @@ def test_script_resolution_pass(repo_with_scripts: Path, pkg_manager_cmd: str):
     assert ctx.ci_has_blocking_command("eslint") is True
 
 
-@pytest.mark.parametrize("pkg_manager_cmd", [
-    "npm run other",
-    "yarn other",
-    "pnpm other",
-    "bun run other",
-])
+@pytest.mark.parametrize(
+    "pkg_manager_cmd",
+    [
+        "npm run other",
+        "yarn other",
+        "pnpm other",
+        "bun run other",
+    ],
+)
 def test_script_resolution_fail_missing_script(repo_with_scripts: Path, pkg_manager_cmd: str):
     """Test that resolution fails gracefully if the script is missing from package.json."""
     ci_dir = repo_with_scripts / ".github" / "workflows"
     ci_dir.mkdir(parents=True, exist_ok=True)
-    ci_config = {
-        "jobs": {"test": {"steps": [{"run": pkg_manager_cmd}]}}
-    }
+    ci_config = {"jobs": {"test": {"steps": [{"run": pkg_manager_cmd}]}}}
     (ci_dir / "ci.yml").write_text(yaml.dump(ci_config))
 
     ctx = RepoContext.build(repo_with_scripts)
@@ -85,14 +78,7 @@ def test_script_resolution_blocking_vs_non_blocking(repo_with_scripts: Path):
     """Test blocking vs non-blocking script detection."""
     ci_dir = repo_with_scripts / ".github" / "workflows"
     ci_dir.mkdir(parents=True, exist_ok=True)
-    ci_config = {
-        "jobs": {
-            "lint": {
-                "continue-on-error": True,
-                "steps": [{"run": "npm run lint"}]
-            }
-        }
-    }
+    ci_config = {"jobs": {"lint": {"continue-on-error": True, "steps": [{"run": "npm run lint"}]}}}
     (ci_dir / "ci.yml").write_text(yaml.dump(ci_config))
 
     ctx = RepoContext.build(repo_with_scripts)

--- a/tests/test_script_resolution.py
+++ b/tests/test_script_resolution.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+import yaml
+
+from ai_harness_scorecard.repo_context import RepoContext
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture
+def repo_with_scripts(tmp_path: Path):
+    """Create a temporary repo with a package.json containing scripts."""
+    package_json = {
+        "name": "test-repo",
+        "scripts": {
+            "lint": "eslint .",
+            "test": "jest",
+            "check": "ruff check ."
+        }
+    }
+    (tmp_path / "package.json").write_text(json.dumps(package_json))
+    return tmp_path
+
+
+@pytest.mark.parametrize("pkg_manager_cmd", [
+    "npm run lint",
+    "yarn lint",
+    "yarn run lint",
+    "pnpm lint",
+    "pnpm run lint",
+    "bun lint",
+    "bun run lint",
+])
+def test_script_resolution_pass(repo_with_scripts: Path, pkg_manager_cmd: str):
+    """Test that various package manager invocations resolve correctly."""
+    # Create CI config using the linter script
+    ci_dir = repo_with_scripts / ".github" / "workflows"
+    ci_dir.mkdir(parents=True)
+    ci_config = {
+        "name": "CI",
+        "on": ["push"],
+        "jobs": {
+            "lint": {
+                "runs-on": "ubuntu-latest",
+                "steps": [
+                    {"run": pkg_manager_cmd}
+                ]
+            }
+        }
+    }
+    (ci_dir / "ci.yml").write_text(yaml.dump(ci_config))
+
+    ctx = RepoContext.build(repo_with_scripts)
+
+    # The linter pattern for eslint is just "eslint"
+    assert ctx.ci_has_command("eslint") is True
+    assert ctx.ci_has_blocking_command("eslint") is True
+
+
+@pytest.mark.parametrize("pkg_manager_cmd", [
+    "npm run other",
+    "yarn other",
+    "pnpm other",
+    "bun run other",
+])
+def test_script_resolution_fail_missing_script(repo_with_scripts: Path, pkg_manager_cmd: str):
+    """Test that resolution fails gracefully if the script is missing from package.json."""
+    ci_dir = repo_with_scripts / ".github" / "workflows"
+    ci_dir.mkdir(parents=True, exist_ok=True)
+    ci_config = {
+        "jobs": {"test": {"steps": [{"run": pkg_manager_cmd}]}}
+    }
+    (ci_dir / "ci.yml").write_text(yaml.dump(ci_config))
+
+    ctx = RepoContext.build(repo_with_scripts)
+    assert ctx.ci_has_command("eslint") is False
+
+
+def test_script_resolution_blocking_vs_non_blocking(repo_with_scripts: Path):
+    """Test blocking vs non-blocking script detection."""
+    ci_dir = repo_with_scripts / ".github" / "workflows"
+    ci_dir.mkdir(parents=True, exist_ok=True)
+    ci_config = {
+        "jobs": {
+            "lint": {
+                "continue-on-error": True,
+                "steps": [{"run": "npm run lint"}]
+            }
+        }
+    }
+    (ci_dir / "ci.yml").write_text(yaml.dump(ci_config))
+
+    ctx = RepoContext.build(repo_with_scripts)
+    assert ctx.ci_has_command("eslint") is True
+    assert ctx.ci_has_blocking_command("eslint") is False


### PR DESCRIPTION
## What does this PR do?

This PR enhances the `RepoContext` to correctly identify linter tools when they are invoked via package manager scripts (e.g., npm run lint, yarn lint, pnpm check, bun run lint) in CI configuration files.

Previously, the scorecard only detected linters if the literal linter command (like eslint or ruff) was found directly in the CI YAML. This change allows the scanner to “look through” the package manager invocation and resolve the actual underlying command from package.json.

## Type of change

- [ ] New check
- [ ] Bug fix
- [x] Refactor
- [ ] Documentation
- [ ] CI/tooling

## Checklist

- [x] Tests added/updated (pass + fail cases for new checks)
- [x] `ruff check` and `ruff format` pass
- [x] `mypy src/` passes
- [x] Self-assessment score doesn't regress (run `ai-harness-scorecard assess .`)
- [x] ARCHITECTURE.md updated if module structure changed

## Testing

Tested against a [TypeScript project](https://github.com/anyulled/my-portfolio-website)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Load and resolve scripts from package.json to detect package-manager script invocations (npm/yarn/pnpm/bun).
  * CI detection now matches resolved scripts as well as direct commands.

* **Bug Fixes**
  * Improved YAML parsing robustness and scheduling detection to handle varied/nullable formats.

* **Tests**
  * Added tests validating script resolution and CI detection behavior (blocking vs non-blocking).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->