### PR TITLE
feat: add PMD/SpotBugs CI detection and cleanup linter logic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,11 +46,7 @@ jobs:
         with:
           python-version: "3.12"
       - run: pip install -e ".[dev]"
-<<<<<<< HEAD
-      - run: pip-audit --ignore-vuln CVE-2026-4539  # pygments 2.19.2, no fix available yet
-=======
-      - run: pip-audit --skip ai-harness-scorecard
->>>>>>> 676cebd (ci: skip ai-harness-scorecard dependency)
+      - run: pip-audit --ignore-vuln CVE-2026-4539 # pygments 2.19.2, no fix available yet
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,11 @@ jobs:
         with:
           python-version: "3.12"
       - run: pip install -e ".[dev]"
+<<<<<<< HEAD
       - run: pip-audit --ignore-vuln CVE-2026-4539  # pygments 2.19.2, no fix available yet
+=======
+      - run: pip-audit --skip ai-harness-scorecard
+>>>>>>> 676cebd (ci: skip ai-harness-scorecard dependency)
 
   test:
     runs-on: ubuntu-latest

--- a/src/ai_harness_scorecard/checks/constraints.py
+++ b/src/ai_harness_scorecard/checks/constraints.py
@@ -62,8 +62,8 @@ class LinterEnforcementCheck(BaseCheck):
         r"ktlint",
         r"swiftlint",
         r"checkstyle",
-        r"pmd:(check|pmd)",
-        r"\bpmd(Main|Test)?\b",
+        r"\bpmd:(check|pmd)\b",
+        r"\b(?:\./)?gradlew?\b.*\b(pmdMain|pmdTest)\b",
     ]
 
     def run(self, context: RepoContext) -> CheckResult:
@@ -95,19 +95,27 @@ class LinterEnforcementCheck(BaseCheck):
                     "Add PMD to your CI pipeline as a blocking job.",
                 )
 
-            pom_xml = context.has_file("pom.xml")
-            if pom_xml and context.search_file(pom_xml, r"maven-pmd-plugin"):
+            pom_xml = context.search_any_file(["pom.xml", "*/pom.xml"], r"maven-pmd-plugin")
+            if pom_xml:
                 return self.partial_result(
                     2.0,
                     "PMD config found but not confirmed in CI",
                     "Add PMD to your CI pipeline as a blocking job.",
                 )
 
-            gradle_file = context.has_file("build.gradle", "build.gradle.kts")
             pmd_gradle_pattern = (
                 r'id\("pmd"\)|id\s+[\'"]pmd[\'"]|apply\s+plugin:\s*[\'"]pmd[\'"]|pmd\s*\{'
             )
-            if gradle_file and context.search_file(gradle_file, pmd_gradle_pattern):
+            gradle_file = context.search_any_file(
+                [
+                    "build.gradle",
+                    "*/build.gradle",
+                    "build.gradle.kts",
+                    "*/build.gradle.kts",
+                ],
+                pmd_gradle_pattern,
+            )
+            if gradle_file:
                 return self.partial_result(
                     2.0,
                     "PMD config found but not confirmed in CI",

--- a/src/ai_harness_scorecard/checks/constraints.py
+++ b/src/ai_harness_scorecard/checks/constraints.py
@@ -82,6 +82,18 @@ class LinterEnforcementCheck(BaseCheck):
         )
 
     @staticmethod
+    def _has_gradle_check_linter(context: RepoContext, *has_gradle_configs: bool) -> bool:
+        gradle_check_pattern = r"\b(?:\./)?gradlew?\b.*\bcheck\b"
+        return any(has_gradle_configs) and context.ci_has_blocking_command(gradle_check_pattern)
+
+    @staticmethod
+    def _has_nonblocking_gradle_check_linter(
+        context: RepoContext, *has_gradle_configs: bool
+    ) -> bool:
+        gradle_check_pattern = r"\b(?:\./)?gradlew?\b.*\bcheck\b"
+        return any(has_gradle_configs) and context.ci_has_command(gradle_check_pattern)
+
+    @staticmethod
     def _has_java_linter_config(
         context: RepoContext,
         *,
@@ -116,9 +128,9 @@ class LinterEnforcementCheck(BaseCheck):
                 return self.pass_result(f"Blocking linter found in CI: {pattern}")
 
         gradle_check_pattern = r"\b(?:\./)?gradlew?\b.*\bcheck\b"
-        if has_pmd_gradle_config and context.ci_has_blocking_command(gradle_check_pattern):
-            return self.pass_result(f"Blocking linter found in CI: {gradle_check_pattern}")
-        if has_spotbugs_gradle_config and context.ci_has_blocking_command(gradle_check_pattern):
+        if self._has_gradle_check_linter(
+            context, has_pmd_gradle_config, has_spotbugs_gradle_config
+        ):
             return self.pass_result(f"Blocking linter found in CI: {gradle_check_pattern}")
 
         for pattern in self.LINTER_PATTERNS:
@@ -129,13 +141,9 @@ class LinterEnforcementCheck(BaseCheck):
                     "Ensure linter job is not set to allow_failure / continue-on-error.",
                 )
 
-        if has_pmd_gradle_config and context.ci_has_command(gradle_check_pattern):
-            return self.partial_result(
-                2.0,
-                f"Linter found in CI ({gradle_check_pattern}) but may not be blocking",
-                "Ensure linter job is not set to allow_failure / continue-on-error.",
-            )
-        if has_spotbugs_gradle_config and context.ci_has_command(gradle_check_pattern):
+        if self._has_nonblocking_gradle_check_linter(
+            context, has_pmd_gradle_config, has_spotbugs_gradle_config
+        ):
             return self.partial_result(
                 2.0,
                 f"Linter found in CI ({gradle_check_pattern}) but may not be blocking",
@@ -221,12 +229,7 @@ class FormatterEnforcementCheck(BaseCheck):
                 )
 
             gradle_file = context.search_any_file(
-                [
-                    "build.gradle",
-                    "*/build.gradle",
-                    "build.gradle.kts",
-                    "*/build.gradle.kts",
-                ],
+                LinterEnforcementCheck.JAVA_BUILD_FILES,
                 r"com\.diffplug\.spotless|spotless|spotlessGradlePlugin",
             )
             if gradle_file:

--- a/src/ai_harness_scorecard/checks/constraints.py
+++ b/src/ai_harness_scorecard/checks/constraints.py
@@ -64,6 +64,8 @@ class LinterEnforcementCheck(BaseCheck):
         r"checkstyle",
         r"\bpmd:(check|aggregate-pmd-check)\b",
         r"\b(?:\./)?gradlew?\b.*\b(pmdMain|pmdTest)\b",
+        r"\bspotbugs:check\b",
+        r"\b(?:\./)?gradlew?\b.*\bspotbugs(Main|Test)\b",
     ]
 
     def run(self, context: RepoContext) -> CheckResult:
@@ -78,6 +80,19 @@ class LinterEnforcementCheck(BaseCheck):
                 "*/build.gradle.kts",
             ],
             pmd_gradle_pattern,
+        )
+        spotbugs_gradle_pattern = (
+            r'id\("com\.github\.spotbugs"\)|id\s+[\'"]com\.github\.spotbugs[\'"]|'
+            r'apply\s+plugin:\s*[\'"]com\.github\.spotbugs[\'"]|spotbugs\s*\{'
+        )
+        has_spotbugs_gradle_config = context.search_any_file(
+            [
+                "build.gradle",
+                "*/build.gradle",
+                "build.gradle.kts",
+                "*/build.gradle.kts",
+            ],
+            spotbugs_gradle_pattern,
         )
 
         for pattern in self.LINTER_PATTERNS:
@@ -119,6 +134,20 @@ class LinterEnforcementCheck(BaseCheck):
                     2.0,
                     "PMD config found but not confirmed in CI",
                     "Add PMD to your CI pipeline as a blocking job.",
+                )
+
+            spotbugs_config = context.has_file("spotbugs-exclude.xml", "*/spotbugs-exclude.xml")
+            spotbugs_pom = context.search_any_file(
+                ["pom.xml", "*/pom.xml"], r"spotbugs-maven-plugin"
+            )
+            has_spotbugs_config = bool(
+                spotbugs_config or spotbugs_pom or has_spotbugs_gradle_config
+            )
+            if has_spotbugs_config:
+                return self.partial_result(
+                    2.0,
+                    "SpotBugs config found but not confirmed in CI",
+                    "Add SpotBugs to your CI pipeline as a blocking job.",
                 )
 
         return self.fail_result(

--- a/src/ai_harness_scorecard/checks/constraints.py
+++ b/src/ai_harness_scorecard/checks/constraints.py
@@ -62,6 +62,8 @@ class LinterEnforcementCheck(BaseCheck):
         r"ktlint",
         r"swiftlint",
         r"checkstyle",
+        r"pmd:(check|pmd)",
+        r"\bpmd(Main|Test)?\b",
     ]
 
     def run(self, context: RepoContext) -> CheckResult:
@@ -83,6 +85,34 @@ class LinterEnforcementCheck(BaseCheck):
                 "Checkstyle config found but not confirmed in CI",
                 "Add checkstyle to your CI pipeline as a blocking job.",
             )
+
+        if "java" in context.languages:
+            pmd_config = context.has_file("pmd.xml", "*/pmd.xml")
+            if pmd_config:
+                return self.partial_result(
+                    2.0,
+                    "PMD config found but not confirmed in CI",
+                    "Add PMD to your CI pipeline as a blocking job.",
+                )
+
+            pom_xml = context.has_file("pom.xml")
+            if pom_xml and context.search_file(pom_xml, r"maven-pmd-plugin"):
+                return self.partial_result(
+                    2.0,
+                    "PMD config found but not confirmed in CI",
+                    "Add PMD to your CI pipeline as a blocking job.",
+                )
+
+            gradle_file = context.has_file("build.gradle", "build.gradle.kts")
+            pmd_gradle_pattern = (
+                r'id\("pmd"\)|id\s+[\'"]pmd[\'"]|apply\s+plugin:\s*[\'"]pmd[\'"]|pmd\s*\{'
+            )
+            if gradle_file and context.search_file(gradle_file, pmd_gradle_pattern):
+                return self.partial_result(
+                    2.0,
+                    "PMD config found but not confirmed in CI",
+                    "Add PMD to your CI pipeline as a blocking job.",
+                )
 
         return self.fail_result(
             "No linter found in CI",

--- a/src/ai_harness_scorecard/checks/constraints.py
+++ b/src/ai_harness_scorecard/checks/constraints.py
@@ -62,14 +62,31 @@ class LinterEnforcementCheck(BaseCheck):
         r"ktlint",
         r"swiftlint",
         r"checkstyle",
-        r"\bpmd:(check|pmd)\b",
+        r"\bpmd:(check|aggregate-pmd-check)\b",
         r"\b(?:\./)?gradlew?\b.*\b(pmdMain|pmdTest)\b",
     ]
 
     def run(self, context: RepoContext) -> CheckResult:
+        pmd_gradle_pattern = (
+            r'id\("pmd"\)|id\s+[\'"]pmd[\'"]|apply\s+plugin:\s*[\'"]pmd[\'"]|pmd\s*\{'
+        )
+        has_pmd_gradle_config = context.search_any_file(
+            [
+                "build.gradle",
+                "*/build.gradle",
+                "build.gradle.kts",
+                "*/build.gradle.kts",
+            ],
+            pmd_gradle_pattern,
+        )
+
         for pattern in self.LINTER_PATTERNS:
             if context.ci_has_blocking_command(pattern):
                 return self.pass_result(f"Blocking linter found in CI: {pattern}")
+
+        gradle_check_pattern = r"\b(?:\./)?gradlew?\b.*\bcheck\b"
+        if has_pmd_gradle_config and context.ci_has_blocking_command(gradle_check_pattern):
+            return self.pass_result(f"Blocking linter found in CI: {gradle_check_pattern}")
 
         for pattern in self.LINTER_PATTERNS:
             if context.ci_has_command(pattern):
@@ -78,6 +95,13 @@ class LinterEnforcementCheck(BaseCheck):
                     f"Linter found in CI ({pattern}) but may not be blocking",
                     "Ensure linter job is not set to allow_failure / continue-on-error.",
                 )
+
+        if has_pmd_gradle_config and context.ci_has_command(gradle_check_pattern):
+            return self.partial_result(
+                2.0,
+                f"Linter found in CI ({gradle_check_pattern}) but may not be blocking",
+                "Ensure linter job is not set to allow_failure / continue-on-error.",
+            )
 
         if "java" in context.languages and context.has_file("checkstyle.xml"):
             return self.partial_result(
@@ -88,34 +112,9 @@ class LinterEnforcementCheck(BaseCheck):
 
         if "java" in context.languages:
             pmd_config = context.has_file("pmd.xml", "*/pmd.xml")
-            if pmd_config:
-                return self.partial_result(
-                    2.0,
-                    "PMD config found but not confirmed in CI",
-                    "Add PMD to your CI pipeline as a blocking job.",
-                )
-
             pom_xml = context.search_any_file(["pom.xml", "*/pom.xml"], r"maven-pmd-plugin")
-            if pom_xml:
-                return self.partial_result(
-                    2.0,
-                    "PMD config found but not confirmed in CI",
-                    "Add PMD to your CI pipeline as a blocking job.",
-                )
-
-            pmd_gradle_pattern = (
-                r'id\("pmd"\)|id\s+[\'"]pmd[\'"]|apply\s+plugin:\s*[\'"]pmd[\'"]|pmd\s*\{'
-            )
-            gradle_file = context.search_any_file(
-                [
-                    "build.gradle",
-                    "*/build.gradle",
-                    "build.gradle.kts",
-                    "*/build.gradle.kts",
-                ],
-                pmd_gradle_pattern,
-            )
-            if gradle_file:
+            has_pmd_config = bool(pmd_config or pom_xml or has_pmd_gradle_config)
+            if has_pmd_config:
                 return self.partial_result(
                     2.0,
                     "PMD config found but not confirmed in CI",
@@ -158,18 +157,24 @@ class FormatterEnforcementCheck(BaseCheck):
                 return self.pass_result(f"Formatter check found in CI: {pattern}")
 
         if "java" in context.languages or "kotlin" in context.languages:
-            pom_xml = context.has_file("pom.xml")
-            if pom_xml and context.search_file(pom_xml, r"spotless-maven-plugin"):
+            pom_xml = context.search_any_file(["pom.xml", "*/pom.xml"], r"spotless-maven-plugin")
+            if pom_xml:
                 return self.partial_result(
                     2.0,
                     "Spotless plugin found but not confirmed in CI",
                     "Add spotless:check to your CI pipeline.",
                 )
 
-            gradle_file = context.has_file("build.gradle", "build.gradle.kts")
-            if gradle_file and context.search_file(
-                gradle_file, r"com\.diffplug\.spotless|spotless|spotlessGradlePlugin"
-            ):
+            gradle_file = context.search_any_file(
+                [
+                    "build.gradle",
+                    "*/build.gradle",
+                    "build.gradle.kts",
+                    "*/build.gradle.kts",
+                ],
+                r"com\.diffplug\.spotless|spotless|spotlessGradlePlugin",
+            )
+            if gradle_file:
                 return self.partial_result(
                     2.0,
                     "Spotless plugin found but not confirmed in CI",

--- a/src/ai_harness_scorecard/checks/constraints.py
+++ b/src/ai_harness_scorecard/checks/constraints.py
@@ -14,6 +14,14 @@ if TYPE_CHECKING:
     from ..repo_context import RepoContext
 
 
+JAVA_BUILD_FILES: list[str] = [
+    "build.gradle",
+    "*/build.gradle",
+    "build.gradle.kts",
+    "*/build.gradle.kts",
+]
+
+
 class CIPipelineExistsCheck(BaseCheck):
     check_id = "ci_pipeline_exists"
     name = "CI Pipeline"
@@ -64,34 +72,30 @@ class LinterEnforcementCheck(BaseCheck):
         r"checkstyle",
         r"\bpmd:(check|aggregate-pmd-check)\b",
         r"\b(?:\./)?gradlew?\b.*\b(pmdMain|pmdTest)\b",
-        r"\bspotbugs:check\b",
-        r"\b(?:\./)?gradlew?\b.*\bspotbugs(Main|Test)\b",
+        r"\bcom\.github\.spotbugs:spotbugs-maven-plugin:(check|spotbugs)\b",
+        r"\bspotbugs:(check|spotbugs)\b",
+        r"\b(?:\./)?gradlew?\b.*\bspotbugs(?:[A-Z]\w*)\b",
     ]
 
-    JAVA_BUILD_FILES = [
-        "build.gradle",
-        "*/build.gradle",
-        "build.gradle.kts",
-        "*/build.gradle.kts",
-    ]
+    GRADLE_CHECK_PATTERN = r"\b(?:\./)?gradlew?\b.*\bcheck\b"
 
     @staticmethod
     def _has_gradle_plugin(context: RepoContext, plugin_pattern: str) -> bool:
-        return bool(
-            context.search_any_file(LinterEnforcementCheck.JAVA_BUILD_FILES, plugin_pattern)
-        )
+        return bool(context.search_any_file(JAVA_BUILD_FILES, plugin_pattern))
 
     @staticmethod
     def _has_gradle_check_linter(context: RepoContext, *has_gradle_configs: bool) -> bool:
-        gradle_check_pattern = r"\b(?:\./)?gradlew?\b.*\bcheck\b"
-        return any(has_gradle_configs) and context.ci_has_blocking_command(gradle_check_pattern)
+        return any(has_gradle_configs) and context.ci_has_blocking_command(
+            LinterEnforcementCheck.GRADLE_CHECK_PATTERN
+        )
 
     @staticmethod
     def _has_nonblocking_gradle_check_linter(
         context: RepoContext, *has_gradle_configs: bool
     ) -> bool:
-        gradle_check_pattern = r"\b(?:\./)?gradlew?\b.*\bcheck\b"
-        return any(has_gradle_configs) and context.ci_has_command(gradle_check_pattern)
+        return any(has_gradle_configs) and context.ci_has_command(
+            LinterEnforcementCheck.GRADLE_CHECK_PATTERN
+        )
 
     @staticmethod
     def _has_java_linter_config(
@@ -100,15 +104,19 @@ class LinterEnforcementCheck(BaseCheck):
         config_files: tuple[str, ...] = (),
         pom_pattern: str | None = None,
         gradle_pattern: str | None = None,
+        has_gradle_config: bool | None = None,
     ) -> bool:
         has_config_file = bool(config_files) and bool(context.has_file(*config_files))
         has_pom_config = False
         if pom_pattern is not None:
             has_pom_config = bool(context.search_any_file(["pom.xml", "*/pom.xml"], pom_pattern))
 
-        has_gradle_config = False
-        if gradle_pattern is not None:
-            has_gradle_config = LinterEnforcementCheck._has_gradle_plugin(context, gradle_pattern)
+        if has_gradle_config is None:
+            has_gradle_config = False
+            if gradle_pattern is not None:
+                has_gradle_config = LinterEnforcementCheck._has_gradle_plugin(
+                    context, gradle_pattern
+                )
 
         return has_config_file or has_pom_config or has_gradle_config
 
@@ -127,11 +135,10 @@ class LinterEnforcementCheck(BaseCheck):
             if context.ci_has_blocking_command(pattern):
                 return self.pass_result(f"Blocking linter found in CI: {pattern}")
 
-        gradle_check_pattern = r"\b(?:\./)?gradlew?\b.*\bcheck\b"
         if self._has_gradle_check_linter(
             context, has_pmd_gradle_config, has_spotbugs_gradle_config
         ):
-            return self.pass_result(f"Blocking linter found in CI: {gradle_check_pattern}")
+            return self.pass_result(f"Blocking linter found in CI: {self.GRADLE_CHECK_PATTERN}")
 
         for pattern in self.LINTER_PATTERNS:
             if context.ci_has_command(pattern):
@@ -146,7 +153,7 @@ class LinterEnforcementCheck(BaseCheck):
         ):
             return self.partial_result(
                 2.0,
-                f"Linter found in CI ({gradle_check_pattern}) but may not be blocking",
+                f"Linter found in CI ({self.GRADLE_CHECK_PATTERN}) but may not be blocking",
                 "Ensure linter job is not set to allow_failure / continue-on-error.",
             )
 
@@ -162,7 +169,7 @@ class LinterEnforcementCheck(BaseCheck):
                 context,
                 config_files=("pmd.xml", "*/pmd.xml"),
                 pom_pattern=r"maven-pmd-plugin",
-                gradle_pattern=pmd_gradle_pattern,
+                has_gradle_config=has_pmd_gradle_config,
             )
             if has_pmd_config:
                 return self.partial_result(
@@ -175,7 +182,7 @@ class LinterEnforcementCheck(BaseCheck):
                 context,
                 config_files=("spotbugs-exclude.xml", "*/spotbugs-exclude.xml"),
                 pom_pattern=r"spotbugs-maven-plugin",
-                gradle_pattern=spotbugs_gradle_pattern,
+                has_gradle_config=has_spotbugs_gradle_config,
             )
             if has_spotbugs_config:
                 return self.partial_result(
@@ -229,7 +236,7 @@ class FormatterEnforcementCheck(BaseCheck):
                 )
 
             gradle_file = context.search_any_file(
-                LinterEnforcementCheck.JAVA_BUILD_FILES,
+                JAVA_BUILD_FILES,
                 r"com\.diffplug\.spotless|spotless|spotlessGradlePlugin",
             )
             if gradle_file:

--- a/src/ai_harness_scorecard/checks/constraints.py
+++ b/src/ai_harness_scorecard/checks/constraints.py
@@ -68,32 +68,48 @@ class LinterEnforcementCheck(BaseCheck):
         r"\b(?:\./)?gradlew?\b.*\bspotbugs(Main|Test)\b",
     ]
 
+    JAVA_BUILD_FILES = [
+        "build.gradle",
+        "*/build.gradle",
+        "build.gradle.kts",
+        "*/build.gradle.kts",
+    ]
+
+    @staticmethod
+    def _has_gradle_plugin(context: RepoContext, plugin_pattern: str) -> bool:
+        return bool(
+            context.search_any_file(LinterEnforcementCheck.JAVA_BUILD_FILES, plugin_pattern)
+        )
+
+    @staticmethod
+    def _has_java_linter_config(
+        context: RepoContext,
+        *,
+        config_files: tuple[str, ...] = (),
+        pom_pattern: str | None = None,
+        gradle_pattern: str | None = None,
+    ) -> bool:
+        has_config_file = bool(config_files) and bool(context.has_file(*config_files))
+        has_pom_config = False
+        if pom_pattern is not None:
+            has_pom_config = bool(context.search_any_file(["pom.xml", "*/pom.xml"], pom_pattern))
+
+        has_gradle_config = False
+        if gradle_pattern is not None:
+            has_gradle_config = LinterEnforcementCheck._has_gradle_plugin(context, gradle_pattern)
+
+        return has_config_file or has_pom_config or has_gradle_config
+
     def run(self, context: RepoContext) -> CheckResult:
         pmd_gradle_pattern = (
             r'id\("pmd"\)|id\s+[\'"]pmd[\'"]|apply\s+plugin:\s*[\'"]pmd[\'"]|pmd\s*\{'
         )
-        has_pmd_gradle_config = context.search_any_file(
-            [
-                "build.gradle",
-                "*/build.gradle",
-                "build.gradle.kts",
-                "*/build.gradle.kts",
-            ],
-            pmd_gradle_pattern,
-        )
+        has_pmd_gradle_config = self._has_gradle_plugin(context, pmd_gradle_pattern)
         spotbugs_gradle_pattern = (
             r'id\("com\.github\.spotbugs"\)|id\s+[\'"]com\.github\.spotbugs[\'"]|'
             r'apply\s+plugin:\s*[\'"]com\.github\.spotbugs[\'"]|spotbugs\s*\{'
         )
-        has_spotbugs_gradle_config = context.search_any_file(
-            [
-                "build.gradle",
-                "*/build.gradle",
-                "build.gradle.kts",
-                "*/build.gradle.kts",
-            ],
-            spotbugs_gradle_pattern,
-        )
+        has_spotbugs_gradle_config = self._has_gradle_plugin(context, spotbugs_gradle_pattern)
 
         for pattern in self.LINTER_PATTERNS:
             if context.ci_has_blocking_command(pattern):
@@ -101,6 +117,8 @@ class LinterEnforcementCheck(BaseCheck):
 
         gradle_check_pattern = r"\b(?:\./)?gradlew?\b.*\bcheck\b"
         if has_pmd_gradle_config and context.ci_has_blocking_command(gradle_check_pattern):
+            return self.pass_result(f"Blocking linter found in CI: {gradle_check_pattern}")
+        if has_spotbugs_gradle_config and context.ci_has_blocking_command(gradle_check_pattern):
             return self.pass_result(f"Blocking linter found in CI: {gradle_check_pattern}")
 
         for pattern in self.LINTER_PATTERNS:
@@ -117,6 +135,12 @@ class LinterEnforcementCheck(BaseCheck):
                 f"Linter found in CI ({gradle_check_pattern}) but may not be blocking",
                 "Ensure linter job is not set to allow_failure / continue-on-error.",
             )
+        if has_spotbugs_gradle_config and context.ci_has_command(gradle_check_pattern):
+            return self.partial_result(
+                2.0,
+                f"Linter found in CI ({gradle_check_pattern}) but may not be blocking",
+                "Ensure linter job is not set to allow_failure / continue-on-error.",
+            )
 
         if "java" in context.languages and context.has_file("checkstyle.xml"):
             return self.partial_result(
@@ -126,9 +150,12 @@ class LinterEnforcementCheck(BaseCheck):
             )
 
         if "java" in context.languages:
-            pmd_config = context.has_file("pmd.xml", "*/pmd.xml")
-            pom_xml = context.search_any_file(["pom.xml", "*/pom.xml"], r"maven-pmd-plugin")
-            has_pmd_config = bool(pmd_config or pom_xml or has_pmd_gradle_config)
+            has_pmd_config = self._has_java_linter_config(
+                context,
+                config_files=("pmd.xml", "*/pmd.xml"),
+                pom_pattern=r"maven-pmd-plugin",
+                gradle_pattern=pmd_gradle_pattern,
+            )
             if has_pmd_config:
                 return self.partial_result(
                     2.0,
@@ -136,12 +163,11 @@ class LinterEnforcementCheck(BaseCheck):
                     "Add PMD to your CI pipeline as a blocking job.",
                 )
 
-            spotbugs_config = context.has_file("spotbugs-exclude.xml", "*/spotbugs-exclude.xml")
-            spotbugs_pom = context.search_any_file(
-                ["pom.xml", "*/pom.xml"], r"spotbugs-maven-plugin"
-            )
-            has_spotbugs_config = bool(
-                spotbugs_config or spotbugs_pom or has_spotbugs_gradle_config
+            has_spotbugs_config = self._has_java_linter_config(
+                context,
+                config_files=("spotbugs-exclude.xml", "*/spotbugs-exclude.xml"),
+                pom_pattern=r"spotbugs-maven-plugin",
+                gradle_pattern=spotbugs_gradle_pattern,
             )
             if has_spotbugs_config:
                 return self.partial_result(

--- a/src/ai_harness_scorecard/repo_context.py
+++ b/src/ai_harness_scorecard/repo_context.py
@@ -17,11 +17,18 @@ LANGUAGE_INDICATORS: dict[str, list[str]] = {
     "javascript": ["package.json"],
     "typescript": ["tsconfig.json"],
     "go": ["go.mod"],
-    "java": ["pom.xml", "build.gradle", "build.gradle.kts"],
+    "java": [
+        "pom.xml",
+        "*/pom.xml",
+        "build.gradle",
+        "*/build.gradle",
+        "build.gradle.kts",
+        "*/build.gradle.kts",
+    ],
     "ruby": ["Gemfile"],
     "csharp": ["*.csproj", "*.sln"],
     "swift": ["Package.swift"],
-    "kotlin": ["build.gradle.kts"],
+    "kotlin": ["build.gradle.kts", "*/build.gradle.kts"],
 }
 
 IGNORED_DIRS = frozenset(

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -62,10 +62,12 @@ class TestAgentInstructionsCheck:
 
 
 class TestLinterEnforcementCheck:
-    def test_pass_with_ruff_in_ci(self, tmp_path: Path) -> None:
-        from ai_harness_scorecard.checks.constraints import LinterEnforcementCheck
-
-        ci_content = """
+    @pytest.mark.parametrize(
+        ("files", "expected_score", "evidence_substring"),
+        [
+            (
+                {
+                    ".github/workflows/ci.yml": """\
 name: CI
 on: push
 jobs:
@@ -74,14 +76,14 @@ jobs:
     steps:
       - run: ruff check src/
 """
-        context = _build_context(tmp_path, {".github/workflows/ci.yml": ci_content})
-        result = LinterEnforcementCheck().run(context)
-        assert result.passed
-
-    def test_pass_with_checkstyle_in_ci(self, tmp_path: Path) -> None:
-        from ai_harness_scorecard.checks.constraints import LinterEnforcementCheck
-
-        ci_content = """
+                },
+                4.0,
+                "ruff",
+            ),
+            (
+                {
+                    "pom.xml": "<project/>",
+                    ".github/workflows/ci.yml": """\
 name: CI
 on: push
 jobs:
@@ -89,18 +91,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: mvn checkstyle:check
-"""
-        context = _build_context(
-            tmp_path, {"pom.xml": "<project/>", ".github/workflows/ci.yml": ci_content}
-        )
-        result = LinterEnforcementCheck().run(context)
-        assert result.passed
-        assert "checkstyle" in result.evidence.lower()
-
-    def test_pass_with_pmd_in_maven_ci(self, tmp_path: Path) -> None:
-        from ai_harness_scorecard.checks.constraints import LinterEnforcementCheck
-
-        ci_content = """
+""",
+                },
+                4.0,
+                "checkstyle",
+            ),
+            (
+                {
+                    "pom.xml": "<project/>",
+                    ".github/workflows/ci.yml": """\
 name: CI
 on: push
 jobs:
@@ -108,19 +107,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: mvn pmd:check
-"""
-        context = _build_context(
-            tmp_path, {"pom.xml": "<project/>", ".github/workflows/ci.yml": ci_content}
-        )
-        result = LinterEnforcementCheck().run(context)
-        assert result.passed
-        assert result.score == pytest.approx(4.0)
-        assert "pmd" in result.evidence.lower()
-
-    def test_pass_with_pmd_in_gradle_ci(self, tmp_path: Path) -> None:
-        from ai_harness_scorecard.checks.constraints import LinterEnforcementCheck
-
-        ci_content = """
+""",
+                },
+                4.0,
+                "pmd",
+            ),
+            (
+                {
+                    "build.gradle": "plugins {}",
+                    ".github/workflows/ci.yml": """\
 name: CI
 on: push
 jobs:
@@ -128,63 +123,81 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: ./gradlew pmdMain
-"""
-        context = _build_context(
-            tmp_path, {"build.gradle": "plugins {}", ".github/workflows/ci.yml": ci_content}
-        )
-        result = LinterEnforcementCheck().run(context)
-        assert result.passed
-        assert result.score == pytest.approx(4.0)
-        assert "pmd" in result.evidence.lower()
-
-    def test_partial_with_checkstyle_xml_no_ci(self, tmp_path: Path) -> None:
-        from ai_harness_scorecard.checks.constraints import LinterEnforcementCheck
-
-        context = _build_context(
-            tmp_path, {"pom.xml": "<project/>", "checkstyle.xml": "<checkstyle/>"}
-        )
-        result = LinterEnforcementCheck().run(context)
-        assert result.passed
-        assert result.score == pytest.approx(2.0)
-        assert "checkstyle config found" in result.evidence.lower()
-
-    def test_partial_with_pmd_xml_no_ci(self, tmp_path: Path) -> None:
-        from ai_harness_scorecard.checks.constraints import LinterEnforcementCheck
-
-        context = _build_context(tmp_path, {"pom.xml": "<project/>", "pmd.xml": "<pmd/>"})
-        result = LinterEnforcementCheck().run(context)
-        assert result.passed
-        assert result.score == pytest.approx(2.0)
-        assert "pmd config found" in result.evidence.lower()
-
-    def test_partial_with_maven_pmd_plugin_no_ci(self, tmp_path: Path) -> None:
-        from ai_harness_scorecard.checks.constraints import LinterEnforcementCheck
-
-        pom_content = "<project><plugin>maven-pmd-plugin</plugin></project>"
-        context = _build_context(tmp_path, {"pom.xml": pom_content})
-        result = LinterEnforcementCheck().run(context)
-        assert result.passed
-        assert result.score == pytest.approx(2.0)
-        assert "pmd config found" in result.evidence.lower()
-
-    def test_partial_with_gradle_pmd_plugin_no_ci(self, tmp_path: Path) -> None:
-        from ai_harness_scorecard.checks.constraints import LinterEnforcementCheck
-
-        gradle_content = """
+""",
+                },
+                4.0,
+                "pmd",
+            ),
+            (
+                {"pom.xml": "<project/>", "checkstyle.xml": "<checkstyle/>"},
+                2.0,
+                "checkstyle config found",
+            ),
+            (
+                {"pom.xml": "<project/>", "pmd.xml": "<pmd/>"},
+                2.0,
+                "pmd config found",
+            ),
+            (
+                {"pom.xml": "<project><plugin>maven-pmd-plugin</plugin></project>"},
+                2.0,
+                "pmd config found",
+            ),
+            (
+                {"services/app/pom.xml": "<project><plugin>maven-pmd-plugin</plugin></project>"},
+                2.0,
+                "pmd config found",
+            ),
+            (
+                {
+                    "build.gradle": """
         plugins {
             id "pmd"
         }
         """
-        context = _build_context(tmp_path, {"build.gradle": gradle_content})
-        result = LinterEnforcementCheck().run(context)
-        assert result.passed
-        assert result.score == pytest.approx(2.0)
-        assert "pmd config found" in result.evidence.lower()
-
-    def test_fail_without_ci(self, tmp_path: Path) -> None:
+                },
+                2.0,
+                "pmd config found",
+            ),
+        ],
+    )
+    def test_linter_enforcement_pass(
+        self,
+        tmp_path: Path,
+        files: dict[str, str],
+        expected_score: float,
+        evidence_substring: str,
+    ) -> None:
         from ai_harness_scorecard.checks.constraints import LinterEnforcementCheck
 
-        context = _build_context(tmp_path)
+        context = _build_context(tmp_path, files)
+        result = LinterEnforcementCheck().run(context)
+        assert result.passed
+        assert result.score == pytest.approx(expected_score)
+        assert evidence_substring in result.evidence.lower()
+
+    @pytest.mark.parametrize(
+        "files",
+        [
+            None,
+            {
+                "pom.xml": "<project/>",
+                ".github/workflows/ci.yml": """\
+name: CI
+on: push
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - run: cat config/pmd.xml
+""",
+            },
+        ],
+    )
+    def test_linter_enforcement_fail(self, tmp_path: Path, files: dict[str, str] | None) -> None:
+        from ai_harness_scorecard.checks.constraints import LinterEnforcementCheck
+
+        context = _build_context(tmp_path, files)
         result = LinterEnforcementCheck().run(context)
         assert not result.passed
 

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -128,6 +128,92 @@ jobs:
     ),
 ]
 
+SPOTBUGS_PARTIAL_LINTER_CASES: list[tuple[dict[str, str], float, str]] = [
+    (
+        {"pom.xml": "<project><plugin>spotbugs-maven-plugin</plugin></project>"},
+        2.0,
+        "spotbugs config found",
+    ),
+    (
+        {"services/app/pom.xml": "<project><plugin>spotbugs-maven-plugin</plugin></project>"},
+        2.0,
+        "spotbugs config found",
+    ),
+    (
+        {
+            "build.gradle": """
+        plugins {
+            id "com.github.spotbugs"
+        }
+        """
+        },
+        2.0,
+        "spotbugs config found",
+    ),
+    (
+        {
+            "services/app/build.gradle": """
+        plugins {
+            id "com.github.spotbugs"
+        }
+        """
+        },
+        2.0,
+        "spotbugs config found",
+    ),
+    (
+        {
+            "services/app/build.gradle.kts": """
+        plugins {
+            id("com.github.spotbugs")
+        }
+        """
+        },
+        2.0,
+        "spotbugs config found",
+    ),
+    (
+        {"pom.xml": "<project/>", "spotbugs-exclude.xml": "<FindBugsFilter/>"},
+        2.0,
+        "spotbugs config found",
+    ),
+]
+
+SPOTBUGS_CI_LINTER_CASES: list[tuple[dict[str, str], float, str]] = [
+    (
+        {
+            "pom.xml": "<project/>",
+            ".github/workflows/ci.yml": """\
+name: CI
+on: push
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - run: mvn spotbugs:check
+""",
+        },
+        4.0,
+        "spotbugs",
+    ),
+    (
+        {
+            "build.gradle": "plugins {}",
+            ".github/workflows/ci.yml": """\
+name: CI
+on: push
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - run: ./gradlew spotbugsMain
+""",
+        },
+        4.0,
+        "spotbugs",
+    ),
+]
+
 
 class TestArchitectureDocCheck:
     def test_pass_with_architecture_md(self, tmp_path: Path) -> None:
@@ -204,12 +290,14 @@ jobs:
                 "checkstyle",
             ),
             *PMD_CI_LINTER_CASES,
+            *SPOTBUGS_CI_LINTER_CASES,
             (
                 {"pom.xml": "<project/>", "checkstyle.xml": "<checkstyle/>"},
                 2.0,
                 "checkstyle config found",
             ),
             *PMD_PARTIAL_LINTER_CASES,
+            *SPOTBUGS_PARTIAL_LINTER_CASES,
         ],
     )
     def test_linter_enforcement_pass(
@@ -253,6 +341,42 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: mvn pmd:pmd
+""",
+            },
+            {
+                "pom.xml": "<project/>",
+                ".github/workflows/ci.yml": """\
+name: CI
+on: push
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - run: cat config/spotbugs-exclude.xml
+""",
+            },
+            {
+                "pom.xml": "<project/>",
+                ".github/workflows/ci.yml": """\
+name: CI
+on: push
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo com.github.spotbugs
+""",
+            },
+            {
+                "pom.xml": "<project/>",
+                ".github/workflows/ci.yml": """\
+name: CI
+on: push
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "spotbugs should run later"
 """,
             },
         ],

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -97,6 +97,46 @@ jobs:
         assert result.passed
         assert "checkstyle" in result.evidence.lower()
 
+    def test_pass_with_pmd_in_maven_ci(self, tmp_path: Path) -> None:
+        from ai_harness_scorecard.checks.constraints import LinterEnforcementCheck
+
+        ci_content = """
+name: CI
+on: push
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - run: mvn pmd:check
+"""
+        context = _build_context(
+            tmp_path, {"pom.xml": "<project/>", ".github/workflows/ci.yml": ci_content}
+        )
+        result = LinterEnforcementCheck().run(context)
+        assert result.passed
+        assert result.score == pytest.approx(4.0)
+        assert "pmd" in result.evidence.lower()
+
+    def test_pass_with_pmd_in_gradle_ci(self, tmp_path: Path) -> None:
+        from ai_harness_scorecard.checks.constraints import LinterEnforcementCheck
+
+        ci_content = """
+name: CI
+on: push
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - run: ./gradlew pmdMain
+"""
+        context = _build_context(
+            tmp_path, {"build.gradle": "plugins {}", ".github/workflows/ci.yml": ci_content}
+        )
+        result = LinterEnforcementCheck().run(context)
+        assert result.passed
+        assert result.score == pytest.approx(4.0)
+        assert "pmd" in result.evidence.lower()
+
     def test_partial_with_checkstyle_xml_no_ci(self, tmp_path: Path) -> None:
         from ai_harness_scorecard.checks.constraints import LinterEnforcementCheck
 
@@ -107,6 +147,39 @@ jobs:
         assert result.passed
         assert result.score == pytest.approx(2.0)
         assert "checkstyle config found" in result.evidence.lower()
+
+    def test_partial_with_pmd_xml_no_ci(self, tmp_path: Path) -> None:
+        from ai_harness_scorecard.checks.constraints import LinterEnforcementCheck
+
+        context = _build_context(tmp_path, {"pom.xml": "<project/>", "pmd.xml": "<pmd/>"})
+        result = LinterEnforcementCheck().run(context)
+        assert result.passed
+        assert result.score == pytest.approx(2.0)
+        assert "pmd config found" in result.evidence.lower()
+
+    def test_partial_with_maven_pmd_plugin_no_ci(self, tmp_path: Path) -> None:
+        from ai_harness_scorecard.checks.constraints import LinterEnforcementCheck
+
+        pom_content = "<project><plugin>maven-pmd-plugin</plugin></project>"
+        context = _build_context(tmp_path, {"pom.xml": pom_content})
+        result = LinterEnforcementCheck().run(context)
+        assert result.passed
+        assert result.score == pytest.approx(2.0)
+        assert "pmd config found" in result.evidence.lower()
+
+    def test_partial_with_gradle_pmd_plugin_no_ci(self, tmp_path: Path) -> None:
+        from ai_harness_scorecard.checks.constraints import LinterEnforcementCheck
+
+        gradle_content = """
+        plugins {
+            id "pmd"
+        }
+        """
+        context = _build_context(tmp_path, {"build.gradle": gradle_content})
+        result = LinterEnforcementCheck().run(context)
+        assert result.passed
+        assert result.score == pytest.approx(2.0)
+        assert "pmd config found" in result.evidence.lower()
 
     def test_fail_without_ci(self, tmp_path: Path) -> None:
         from ai_harness_scorecard.checks.constraints import LinterEnforcementCheck

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -198,6 +198,22 @@ jobs:
     ),
     (
         {
+            "pom.xml": "<project/>",
+            ".github/workflows/ci.yml": """\
+name: CI
+on: push
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - run: ./mvnw com.github.spotbugs:spotbugs-maven-plugin:check
+""",
+        },
+        4.0,
+        "spotbugs-maven-plugin",
+    ),
+    (
+        {
             "build.gradle": "plugins {}",
             ".github/workflows/ci.yml": """\
 name: CI

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -212,6 +212,26 @@ jobs:
         4.0,
         "spotbugs",
     ),
+    (
+        {
+            "build.gradle": """
+        plugins {
+            id "com.github.spotbugs"
+        }
+        """,
+            ".github/workflows/ci.yml": """\
+name: CI
+on: push
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - run: ./gradlew check
+""",
+        },
+        4.0,
+        "check",
+    ),
 ]
 
 

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -49,6 +49,28 @@ PMD_PARTIAL_LINTER_CASES: list[tuple[dict[str, str], float, str]] = [
         2.0,
         "pmd config found",
     ),
+    (
+        {
+            "services/app/build.gradle": """
+        plugins {
+            id "pmd"
+        }
+        """
+        },
+        2.0,
+        "pmd config found",
+    ),
+    (
+        {
+            "services/app/build.gradle.kts": """
+        plugins {
+            id("pmd")
+        }
+        """
+        },
+        2.0,
+        "pmd config found",
+    ),
 ]
 
 PMD_CI_LINTER_CASES: list[tuple[dict[str, str], float, str]] = [
@@ -83,6 +105,26 @@ jobs:
         },
         4.0,
         "pmd",
+    ),
+    (
+        {
+            "build.gradle": """
+        plugins {
+            id "pmd"
+        }
+        """,
+            ".github/workflows/ci.yml": """\
+name: CI
+on: push
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - run: ./gradlew check
+""",
+        },
+        4.0,
+        "check",
     ),
 ]
 
@@ -199,6 +241,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: cat config/pmd.xml
+""",
+            },
+            {
+                "pom.xml": "<project/>",
+                ".github/workflows/ci.yml": """\
+name: CI
+on: push
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - run: mvn pmd:pmd
 """,
             },
         ],
@@ -354,6 +408,20 @@ jobs:
         """
         # RepoContext detects kotlin if build.gradle.kts exists
         context = _build_context(tmp_path, {"build.gradle.kts": gradle_content, "src/Main.kt": ""})
+        result = FormatterEnforcementCheck().run(context)
+        assert result.passed
+        assert result.score == pytest.approx(2.0)
+        assert "spotless plugin found" in result.evidence.lower()
+
+    def test_formatter_enforcement_pass_nested_gradle_spotless(self, tmp_path: Path) -> None:
+        from ai_harness_scorecard.checks.constraints import FormatterEnforcementCheck
+
+        gradle_content = """
+        plugins {
+            id "com.diffplug.spotless" version "6.13.0"
+        }
+        """
+        context = _build_context(tmp_path, {"services/app/build.gradle": gradle_content})
         result = FormatterEnforcementCheck().run(context)
         assert result.passed
         assert result.score == pytest.approx(2.0)

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -22,6 +22,71 @@ def _build_context(tmp_path: Path, files: dict[str, str] | None = None) -> RepoC
     return RepoContext.build(tmp_path)
 
 
+PMD_PARTIAL_LINTER_CASES: list[tuple[dict[str, str], float, str]] = [
+    (
+        {"pom.xml": "<project/>", "pmd.xml": "<pmd/>"},
+        2.0,
+        "pmd config found",
+    ),
+    (
+        {"pom.xml": "<project><plugin>maven-pmd-plugin</plugin></project>"},
+        2.0,
+        "pmd config found",
+    ),
+    (
+        {"services/app/pom.xml": "<project><plugin>maven-pmd-plugin</plugin></project>"},
+        2.0,
+        "pmd config found",
+    ),
+    (
+        {
+            "build.gradle": """
+        plugins {
+            id "pmd"
+        }
+        """
+        },
+        2.0,
+        "pmd config found",
+    ),
+]
+
+PMD_CI_LINTER_CASES: list[tuple[dict[str, str], float, str]] = [
+    (
+        {
+            "pom.xml": "<project/>",
+            ".github/workflows/ci.yml": """\
+name: CI
+on: push
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - run: mvn pmd:check
+""",
+        },
+        4.0,
+        "pmd",
+    ),
+    (
+        {
+            "build.gradle": "plugins {}",
+            ".github/workflows/ci.yml": """\
+name: CI
+on: push
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - run: ./gradlew pmdMain
+""",
+        },
+        4.0,
+        "pmd",
+    ),
+]
+
+
 class TestArchitectureDocCheck:
     def test_pass_with_architecture_md(self, tmp_path: Path) -> None:
         from ai_harness_scorecard.checks.documentation import ArchitectureDocCheck
@@ -96,69 +161,13 @@ jobs:
                 4.0,
                 "checkstyle",
             ),
-            (
-                {
-                    "pom.xml": "<project/>",
-                    ".github/workflows/ci.yml": """\
-name: CI
-on: push
-jobs:
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - run: mvn pmd:check
-""",
-                },
-                4.0,
-                "pmd",
-            ),
-            (
-                {
-                    "build.gradle": "plugins {}",
-                    ".github/workflows/ci.yml": """\
-name: CI
-on: push
-jobs:
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - run: ./gradlew pmdMain
-""",
-                },
-                4.0,
-                "pmd",
-            ),
+            *PMD_CI_LINTER_CASES,
             (
                 {"pom.xml": "<project/>", "checkstyle.xml": "<checkstyle/>"},
                 2.0,
                 "checkstyle config found",
             ),
-            (
-                {"pom.xml": "<project/>", "pmd.xml": "<pmd/>"},
-                2.0,
-                "pmd config found",
-            ),
-            (
-                {"pom.xml": "<project><plugin>maven-pmd-plugin</plugin></project>"},
-                2.0,
-                "pmd config found",
-            ),
-            (
-                {"services/app/pom.xml": "<project><plugin>maven-pmd-plugin</plugin></project>"},
-                2.0,
-                "pmd config found",
-            ),
-            (
-                {
-                    "build.gradle": """
-        plugins {
-            id "pmd"
-        }
-        """
-                },
-                2.0,
-                "pmd config found",
-            ),
+            *PMD_PARTIAL_LINTER_CASES,
         ],
     )
     def test_linter_enforcement_pass(


### PR DESCRIPTION
## What does this PR do?

This PR improves Java ecosystem safeguard detection in the scorecard by adding and refining PMD/SpotBugs enforcement checks, plus related CI pattern handling and test updates. Relates to #16 

Why this is needed:
- Repositories using PMD/SpotBugs (including multi-module setups) were under-detected in some CI/build layouts.
- Detection logic had duplication that made maintenance harder.

## Type of change

- [ ] New check
- [x] Bug fix
- [x] Refactor
- [ ] Documentation
- [x] CI/tooling

## Checklist

- [x] Tests added/updated (pass + fail cases for new checks)
- [x] `ruff check` and `ruff format` pass
- [x] `mypy src/` passes
- [x] Self-assessment score doesn't regress (run `ai-harness-scorecard assess .`)
- [x] ARCHITECTURE.md updated if module structure changed

## Testing

Implemented coverage in `tests/test_checks.py` for PMD/SpotBugs-related detection scenarios and refactors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Broader Java/Kotlin detection to find build files in subdirectories
  * Enhanced linter enforcement to better detect Gradle-based PMD/SpotBugs and distinguish blocking vs non-blocking CI checks
  * Improved formatter detection for Spotless in nested Gradle projects

* **Tests**
  * Added parametrized tests covering many linter/formatter and CI scenarios, including nested Gradle layouts
<!-- end of auto-generated comment: release notes by coderabbit.ai -->