### PR TITLE
Add harness documentation check

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Good foundation. Some gaps in enforcement or feedback loops.
 ┌──────────────────────────┬────────┬───────┬────────┐
 │ Category                 │ Weight │ Score │ Checks │
 ├──────────────────────────┼────────┼───────┼────────┤
-│ Architectural Docs       │    20% │   60% │    3/5 │
+│ Architectural Docs       │    20% │   60% │    3/6 │
 │ Mechanical Constraints   │    25% │   91% │    6/7 │
 │ Testing & Stability      │    25% │   72% │    5/8 │
 │ Review & Drift           │    15% │   60% │    3/6 │

--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ ai-harness-scorecard assess . --format json
 
 ## What It Checks
 
-Five categories, 31 checks, each grounded in published research:
+Five categories, 32 checks, each grounded in published research:
 
 ### 1. Architectural Documentation (20%)
-Architecture docs, agent instructions, ADRs, module boundary constraints, API documentation.
+Architecture docs, agent instructions, harness docs, ADRs, module boundary constraints, API documentation.
 
 ### 2. Mechanical Constraints (25%)
 CI pipeline, linter/formatter enforcement, type safety, dependency auditing, conventional commits, unsafe code policies.

--- a/src/ai_harness_scorecard/checks/documentation.py
+++ b/src/ai_harness_scorecard/checks/documentation.py
@@ -5,6 +5,7 @@ Blog principle: 'Document architecture in the repo, not in people's heads.'
 
 from __future__ import annotations
 
+import re
 from typing import TYPE_CHECKING
 
 from .base import BaseCheck
@@ -63,6 +64,64 @@ class AgentInstructionsCheck(BaseCheck):
             "No AI agent instruction files found",
             "Create CLAUDE.md or AGENTS.md with project context, code style, "
             "and constraints so AI agents produce consistent output.",
+        )
+
+
+class HarnessDocsCheck(BaseCheck):
+    check_id = "documentation.harness_docs"
+    name = "Harness Documentation"
+    description = "Quality pipeline, CI stages, or quality gates documented for contributors"
+    max_points = 2.0
+    source = "Morris 2026 - harness engineering"
+
+    DOCUMENTATION_FILES = [
+        "contributing.md",
+        "docs/*.md",
+        "docs/*.rst",
+        "doc/*.md",
+        "doc/*.rst",
+    ]
+
+    PIPELINE_PATTERNS = [
+        r"\bci\s+(pipeline|stages?|workflow)\b",
+        r"\bquality\s+gates?\b",
+        r"\bpre-commit\b",
+        r"\bdevelopment\s+workflow\b",
+        r"how\s+to\s+add\s+(a\s+)?(new\s+)?(check|quality\s+gate|ci\s+job)",
+        r"run\s+in\s+ci\s+and\s+must\s+pass",
+    ]
+
+    COMMENTED_CI_PATTERN = r"(?m)^\s*#.*\b(ci|quality|check|lint|test|type|gate|workflow)\b"
+
+    def run(self, context: RepoContext) -> CheckResult:
+        for pattern in self.PIPELINE_PATTERNS:
+            found = context.search_any_file(self.DOCUMENTATION_FILES, pattern)
+            if found:
+                return self.pass_result(f"Quality pipeline documented in {found}")
+
+        contributing = context.has_file("contributing.md")
+        if contributing:
+            return self.partial_result(
+                1.0,
+                f"Found {contributing}, but no documented quality pipeline",
+                "Document CI stages, quality gates, or how to add a new quality check.",
+            )
+
+        if context.ci_configs and re.search(
+            self.COMMENTED_CI_PATTERN,
+            context.ci_raw_content(),
+            re.IGNORECASE,
+        ):
+            return self.partial_result(
+                1.0,
+                "CI config comments mention quality checks",
+                "Move CI stage and quality gate guidance into CONTRIBUTING.md or docs/.",
+            )
+
+        return self.fail_result(
+            "No quality pipeline documentation found",
+            "Document the quality pipeline, CI stages, quality gates, or how to add a "
+            "new check in CONTRIBUTING.md or docs/.",
         )
 
 
@@ -189,6 +248,7 @@ class APIContractsCheck(BaseCheck):
 DOCUMENTATION_CHECKS: list[BaseCheck] = [
     ArchitectureDocCheck(),
     AgentInstructionsCheck(),
+    HarnessDocsCheck(),
     ADRPresenceCheck(),
     ModuleBoundaryDocsCheck(),
     APIContractsCheck(),

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -2,14 +2,16 @@
 
 from __future__ import annotations
 
-from pathlib import Path
-from tempfile import TemporaryDirectory
+from typing import TYPE_CHECKING
 
 import pytest
-from hypothesis import given
+from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
 
 from ai_harness_scorecard.repo_context import RepoContext
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 def _build_context(tmp_path: Path, files: dict[str, str] | None = None) -> RepoContext:
@@ -343,8 +345,10 @@ class TestHarnessDocsCheck:
         separator=st.sampled_from([" ", "  ", "\t"]),
         uppercase=st.booleans(),
     )
+    @settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
     def test_harness_docs_pass_with_pipeline_wording_variants(
         self,
+        tmp_path: Path,
         words: tuple[str, ...],
         separator: str,
         uppercase: bool,
@@ -355,19 +359,17 @@ class TestHarnessDocsCheck:
         if uppercase:
             phrase = phrase.upper()
 
-        with TemporaryDirectory() as tmp_dir:
-            context = _build_context(
-                Path(tmp_dir),
-                {
-                    "docs/development.md": (
-                        "# Development\n\n"
-                        f"## {phrase}\n\n"
-                        "Document the checks contributors run before merging changes."
-                    )
-                },
-            )
-
-            result = HarnessDocsCheck().run(context)
+        context = _build_context(
+            tmp_path,
+            {
+                "docs/development.md": (
+                    "# Development\n\n"
+                    f"## {phrase}\n\n"
+                    "Document the checks contributors run before merging changes."
+                )
+            },
+        )
+        result = HarnessDocsCheck().run(context)
 
         assert result.passed
         assert result.score == pytest.approx(2.0)

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -293,7 +293,7 @@ class TestAgentInstructionsCheck:
 
 
 class TestHarnessDocsCheck:
-    def test_harness_docs_pass_with_ci_pipeline_docs(self, tmp_path: Path) -> None:
+    def test_harness_docs_pass(self, tmp_path: Path) -> None:
         from ai_harness_scorecard.checks.documentation import HarnessDocsCheck
 
         context = _build_context(
@@ -313,7 +313,7 @@ class TestHarnessDocsCheck:
         assert result.score == pytest.approx(2.0)
         assert "quality pipeline" in result.evidence.lower()
 
-    def test_harness_docs_partial_with_contributing_only(self, tmp_path: Path) -> None:
+    def test_harness_docs_pass_partial(self, tmp_path: Path) -> None:
         from ai_harness_scorecard.checks.documentation import HarnessDocsCheck
 
         context = _build_context(tmp_path, {"CONTRIBUTING.md": "# Contributing\n\nWelcome."})
@@ -322,7 +322,7 @@ class TestHarnessDocsCheck:
         assert result.score == pytest.approx(1.0)
         assert "contributing.md" in result.evidence.lower()
 
-    def test_harness_docs_fail_without_pipeline_docs(self, tmp_path: Path) -> None:
+    def test_harness_docs_fail(self, tmp_path: Path) -> None:
         from ai_harness_scorecard.checks.documentation import HarnessDocsCheck
 
         context = _build_context(tmp_path, {"README.md": "# Project"})
@@ -346,7 +346,7 @@ class TestHarnessDocsCheck:
         uppercase=st.booleans(),
     )
     @settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
-    def test_harness_docs_pass_with_pipeline_wording_variants(
+    def test_harness_docs_pass_variants(
         self,
         tmp_path: Path,
         words: tuple[str, ...],

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -290,6 +290,46 @@ class TestAgentInstructionsCheck:
         assert not result.passed
 
 
+class TestHarnessDocsCheck:
+    def test_harness_docs_pass_with_ci_pipeline_docs(self, tmp_path: Path) -> None:
+        from ai_harness_scorecard.checks.documentation import HarnessDocsCheck
+
+        context = _build_context(
+            tmp_path,
+            {
+                "docs/development.md": (
+                    "# Development\n\n"
+                    "## CI pipeline\n\n"
+                    "The quality gates run lint, type checks, security scans, and tests. "
+                    "To add a new check, update the CI workflow and document the new gate here."
+                )
+            },
+        )
+        result = HarnessDocsCheck().run(context)
+        assert result.check_id == "documentation.harness_docs"
+        assert result.passed
+        assert result.score == pytest.approx(2.0)
+        assert "quality pipeline" in result.evidence.lower()
+
+    def test_harness_docs_partial_with_contributing_only(self, tmp_path: Path) -> None:
+        from ai_harness_scorecard.checks.documentation import HarnessDocsCheck
+
+        context = _build_context(tmp_path, {"CONTRIBUTING.md": "# Contributing\n\nWelcome."})
+        result = HarnessDocsCheck().run(context)
+        assert result.passed
+        assert result.score == pytest.approx(1.0)
+        assert "contributing.md" in result.evidence.lower()
+
+    def test_harness_docs_fail_without_pipeline_docs(self, tmp_path: Path) -> None:
+        from ai_harness_scorecard.checks.documentation import HarnessDocsCheck
+
+        context = _build_context(tmp_path, {"README.md": "# Project"})
+        result = HarnessDocsCheck().run(context)
+        assert not result.passed
+        assert result.score == pytest.approx(0.0)
+        assert "quality pipeline" in result.remediation.lower()
+
+
 class TestLinterEnforcementCheck:
     @pytest.mark.parametrize(
         ("files", "expected_score", "evidence_substring"),

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from pathlib import Path
+from pathlib import Path
+from tempfile import TemporaryDirectory
 
 import pytest
+from hypothesis import given
+from hypothesis import strategies as st
 
 from ai_harness_scorecard.repo_context import RepoContext
 
@@ -328,6 +328,49 @@ class TestHarnessDocsCheck:
         assert not result.passed
         assert result.score == pytest.approx(0.0)
         assert "quality pipeline" in result.remediation.lower()
+
+    @given(
+        words=st.sampled_from(
+            [
+                ("ci", "pipeline"),
+                ("ci", "workflow"),
+                ("quality", "gate"),
+                ("quality", "gates"),
+                ("development", "workflow"),
+                ("run", "in", "ci", "and", "must", "pass"),
+            ]
+        ),
+        separator=st.sampled_from([" ", "  ", "\t"]),
+        uppercase=st.booleans(),
+    )
+    def test_harness_docs_pass_with_pipeline_wording_variants(
+        self,
+        words: tuple[str, ...],
+        separator: str,
+        uppercase: bool,
+    ) -> None:
+        from ai_harness_scorecard.checks.documentation import HarnessDocsCheck
+
+        phrase = separator.join(words)
+        if uppercase:
+            phrase = phrase.upper()
+
+        with TemporaryDirectory() as tmp_dir:
+            context = _build_context(
+                Path(tmp_dir),
+                {
+                    "docs/development.md": (
+                        "# Development\n\n"
+                        f"## {phrase}\n\n"
+                        "Document the checks contributors run before merging changes."
+                    )
+                },
+            )
+
+            result = HarnessDocsCheck().run(context)
+
+        assert result.passed
+        assert result.score == pytest.approx(2.0)
 
 
 class TestLinterEnforcementCheck:


### PR DESCRIPTION
## What does this PR do?

Adds the `documentation.harness_docs` check proposed in #33. The check awards full credit when CONTRIBUTING/docs describe CI stages, quality gates, pre-commit, development workflow, or how to add a quality check; partial credit is available for a CONTRIBUTING.md without pipeline detail or CI comments documenting checks.

Closes #33.

## Type of change

- [x] New check
- [ ] Bug fix
- [ ] Refactor
- [x] Documentation
- [ ] CI/tooling

## Checklist

- [x] Tests added/updated (pass + fail cases for new checks)
- [x] `ruff check` and `ruff format` pass
- [x] `mypy src/` passes
- [x] Self-assessment score does not regress (`31/32` checks pass, grade A 92.0/100)
- [x] ARCHITECTURE.md updated if module structure changed (not applicable)

## Testing

- `.venv/bin/python -m pytest tests/test_checks.py -q -k harness_docs`
- `.venv/bin/python -m pytest tests/test_checks.py -q`
- `.venv/bin/python -m pytest -q`
- `.venv/bin/ruff check src/ tests/`
- `.venv/bin/ruff format --check src/ tests/`
- `.venv/bin/mypy src/`
- `.venv/bin/bandit -r src/ -c pyproject.toml`
- `.venv/bin/pip-audit`
- `.venv/bin/ai-harness-scorecard assess .`
- `git diff --check`

## AI Usage

This PR was prepared with AI assistance. I reviewed the implementation and validated it with the commands listed above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a check that verifies project documentation includes quality-pipeline information (CI/workflow, quality gates, contribution guidance).

* **Documentation**
  * Updated total check count (31 → 32) and adjusted example output wording to reflect the new count.

* **Tests**
  * Added unit and property-based tests covering pass/partial/fail outcomes for the new documentation check.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/markmishaev76/ai-harness-scorecard/pull/50?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->